### PR TITLE
Clarify that only labels are authoritative

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,6 +8,8 @@ Please [file an issue](https://github.com/WebKit/standards-positions/issues/new)
 
 ### Possible positions
 
+**Please note:** Only once a label is assigned to an issue does it represent WebKit's position. Individual responses to issues do not represent the WebKit team's position on a standard or feature. 
+
 - `support` - WebKit sees this specification as conceptually good, and worth prototyping, getting feedback on its value, and iterating.
 - `neutral` - WebKit does not see this specification as harmful, but is not convinced that it is a good approach or worth working on.
 - `oppose` - WebKit considers this specification to be harmful in its current state.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,9 @@ Please [file an issue](https://github.com/WebKit/standards-positions/issues/new)
 
 ### Possible positions
 
-**Please note:** Only once a label is assigned to an issue does it represent WebKit's position. Individual responses to issues do not represent the WebKit team's position on a standard or feature. 
+**Please note:** Only once a label is assigned to an issue does it represent WebKit's position.
+Individual responses to issues do not represent the WebKit team's position on a standard or feature.
+Positions are not final. We are happy to revisit postions as new information becomes available.
 
 - `support` - WebKit sees this specification as conceptually good, and worth prototyping, getting feedback on its value, and iterating.
 - `neutral` - WebKit does not see this specification as harmful, but is not convinced that it is a good approach or worth working on.

--- a/README.md
+++ b/README.md
@@ -8,7 +8,7 @@ Please [file an issue](https://github.com/WebKit/standards-positions/issues/new)
 
 ### Possible positions
 
-**Please note:** Only once a label is assigned to an issue does it represent WebKit's position.
+Only once a label is assigned to an issue does it represent WebKit's position.
 Individual responses to issues do not represent the WebKit team's position on a standard or feature.
 Positions are not final. We are happy to revisit postions as new information becomes available.
 


### PR DESCRIPTION
Add some clarifying text about labels being authoritative, rather than comments in issues. 

Make it clear that we may revise our position as new information becomes available. 