### PR TITLE
Add link to webkit-dev mailing list archives

### DIFF
--- a/README.md
+++ b/README.md
@@ -6,6 +6,8 @@ The [WebKit Open Source Project](https://webkit.org) uses [this GitHub repositor
 
 Please [file an issue](https://github.com/WebKit/standards-positions/issues/new) if you'd like us to generate a position on some web-facing API.
 
+For previous positions see the [webkit-dev mailing list archives](https://lists.webkit.org/pipermail/webkit-dev/).
+
 ### Possible positions
 
 - `support` - WebKit sees this specification as conceptually good, and worth prototyping, getting feedback on its value, and iterating.


### PR DESCRIPTION
I just had the case wanting to look up an old position and it was cumbersome to find the archive, hence this PR is adding a direct link.

Feel free to change the wording, position or even the link if there's better one, perhaps filtering to show only positions, but I do think a link to the past of some sort should be there.

Great you moved here, btw.! :) 🎉 