### PR TITLE
Encourage a proper title

### DIFF
--- a/.github/ISSUE_TEMPLATE/request-for-position.yml
+++ b/.github/ISSUE_TEMPLATE/request-for-position.yml
@@ -16,8 +16,8 @@ body:
   - type: input
     id: spec-title
     attributes:
-      label: "Title of the spec"
-      placeholder: "CSS Frobnication Module, Level 5"
+      label: "Title of the proposal"
+      placeholder: "CSS frobnication-aspect: 6"
     validations:
       required: true
   - type: input

--- a/summary.py
+++ b/summary.py
@@ -107,6 +107,7 @@ def process_body(issue):
 
     yaml_mapping = {
         "Title of the spec": "title",
+        "Title of the proposal": "title",
         "URL to the spec": "url",
         "URL to the spec's repository": "github",
         "Issue Tracker URL": "issues",


### PR DESCRIPTION
By asking for the specification title, we get titles such as "DOM" rather than "Node.prototype.moveBefore()".

As it's quite a bit of work to fix them all up, I hope this modest change will get everyone aligned.